### PR TITLE
Fix Env Injector deployment template

### DIFF
--- a/stable/azure-key-vault-env-injector/templates/deployment.yaml
+++ b/stable/azure-key-vault-env-injector/templates/deployment.yaml
@@ -63,8 +63,8 @@ spec:
             value: {{ .Values.customAuth.autoInject.enabled | quote }}
             {{- end}}
             {{- if .Values.customAuth.autoInject.secretName }}
-          - NAME: CUSTOM_AUTH_INJECT_SECRET_NAME
-            VALUE: {{ .Values.customAuth.autoInject.secretName | quote }}
+          - name: CUSTOM_AUTH_INJECT_SECRET_NAME
+            value: {{ .Values.customAuth.autoInject.secretName | quote }}
             {{- end}}
           {{- end}}
           - name: DEBUG


### PR DESCRIPTION
Env Injector helm installation fails if `customAuth.autoInject.secretName` parameter is set because of capitals in the deployment template (helm v3.0.2).

This PR fixes the issue #10 by setting the invalid YAML keys to lower case.

Can be tested with running the following:

```
$ cd stable
$ helm lint azure-key-vault-env-injector
$ helm dependency update azure-key-vault-env-injector
$ helm install \
  --set customAuth.enabled=true \
  --set customAuth.autoInject.enabled=true \
  --set customAuth.autoInject.secretName=azure-key-vault-secret \
  --set env.AZURE_TENANT_ID=foo \
  --set env.AZURE_CLIENT_ID=bar \
  --set env.AZURE_CLIENT_SECRET=baz \
  test ./azure-key-vault-env-injector
```

Produces:

```
NAME: test
LAST DEPLOYED: <......> 
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```