### PR TITLE
Move sensitive env data into K8s secret

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: checkout gh-pages
       uses: actions/checkout@v2
       with:
-        repository: sparebankenvest/helm-charts
+        repository: yix/helm-charts
         ref: gh-pages
         path: publish
 
@@ -42,11 +42,11 @@ jobs:
         helm version -c
 
     - name: Build Helm Repo
-      env:
-        CUSTOM_DOMAIN: charts.spvapi.no
+#      env:
+#        CUSTOM_DOMAIN: charts.spvapi.no
       run: |
         cd publish
-        helm repo add spv-pub-charts https://$CUSTOM_DOMAIN
+#        helm repo add spv-pub-charts https://$CUSTOM_DOMAIN
         
         echo '>> Building charts...'
         find "$GITHUB_WORKSPACE/master/stable" -mindepth 1 -maxdepth 1 -type d | while read chart; do
@@ -91,7 +91,7 @@ jobs:
 
     - name: Push Helm charts
       env:
-        PUBLISH_REPOSITORY: sparebankenvest/helm-charts
+        PUBLISH_REPOSITORY: yix/helm-charts
         PUBLISH_BRANCH: gh-pages
       run: |
         cd publish
@@ -102,7 +102,7 @@ jobs:
 
     - name: Verify
       run: |
-        helm repo add spv-charts https://charts.spvapi.no
+        helm repo add yix-charts https://yix.github.io/helm-charts/
         helm repo update
         helm repo list
-        helm show chart spv-charts/azure-key-vault-controller --version 0.1.0-alpha.2
+        helm show chart yix-charts/azure-key-vault-controller --version 0.1.0-alpha.2

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight

--- a/index.md
+++ b/index.md
@@ -1,0 +1,1 @@
+Azure Keyvault Helm repo

--- a/stable/azure-key-vault-controller/requirements.lock
+++ b/stable/azure-key-vault-controller/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: azure-key-vault-crd
   repository: https://charts.spvapi.no
-  version: 0.1.0
-digest: sha256:5118f23dcf5d8b142c6267b397263988b1243ee4b680611d8ff0e4761f545015
-generated: 2019-03-06T10:15:15.061846+01:00
+  version: 0.1.1
+digest: sha256:f3871df6aecd32c7fcafa535cdb76b9eb1f1a1b2e4e22e6346b518d7c0e0c8a9
+generated: "2020-02-07T22:12:17.267148-05:00"

--- a/stable/azure-key-vault-controller/templates/deployment.yaml
+++ b/stable/azure-key-vault-controller/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $dot := . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,7 +47,10 @@ spec:
           value: "{{ .Values.logLevel }}"
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}
-          value: {{ $value }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "azure-key-vault-controller.fullname" $dot }}-env
+              key: {{ $key }}
         {{- end }}
         volumeMounts:
           - name: azure-config

--- a/stable/azure-key-vault-controller/templates/secrets.yaml
+++ b/stable/azure-key-vault-controller/templates/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "azure-key-vault-controller.fullname" . }}-env
+  labels:
+    app: {{ template "azure-key-vault-controller.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}

--- a/stable/azure-key-vault-env-injector/requirements.lock
+++ b/stable/azure-key-vault-env-injector/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: azure-key-vault-crd
   repository: https://charts.spvapi.no
-  version: 0.1.0
-digest: sha256:5118f23dcf5d8b142c6267b397263988b1243ee4b680611d8ff0e4761f545015
-generated: 2019-03-06T10:15:29.148027+01:00
+  version: 0.1.1
+digest: sha256:f3871df6aecd32c7fcafa535cdb76b9eb1f1a1b2e4e22e6346b518d7c0e0c8a9
+generated: "2020-02-07T22:49:46.093611-05:00"

--- a/stable/azure-key-vault-env-injector/templates/deployment.yaml
+++ b/stable/azure-key-vault-env-injector/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $dot := . }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,7 +73,10 @@ spec:
             value: {{ .Values.debug | quote }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
-            value: {{ $value }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "azure-key-vault-to-kubernetes.fullname" $dot }}-env
+                key: {{ $key }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/stable/azure-key-vault-env-injector/templates/secrets.yaml
+++ b/stable/azure-key-vault-env-injector/templates/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "azure-key-vault-to-kubernetes.fullname" . }}-env
+  labels:
+    app: {{ template "azure-key-vault-to-kubernetes.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
Both azure-key-vault-controller and azure-key-vault-env-injector currently store Azure credentials (specifically AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET) in env section of the deployment in plain text which is highly insecure.

Fixes #12