### PR TITLE
Put (potentially)sensitive env data into K8s secret

### DIFF
--- a/stable/azure-key-vault-controller/templates/deployment.yaml
+++ b/stable/azure-key-vault-controller/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $dot := . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,7 +47,10 @@ spec:
           value: "{{ .Values.logLevel }}"
         {{- range $key, $value := .Values.env }}
         - name: {{ $key }}
-          value: {{ $value }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "azure-key-vault-controller.fullname" $dot }}-env
+              key: {{ $key }}
         {{- end }}
         volumeMounts:
           - name: azure-config

--- a/stable/azure-key-vault-controller/templates/secrets.yaml
+++ b/stable/azure-key-vault-controller/templates/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "azure-key-vault-controller.fullname" . }}-env
+  labels:
+    app: {{ template "azure-key-vault-controller.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}

--- a/stable/azure-key-vault-env-injector/templates/deployment.yaml
+++ b/stable/azure-key-vault-env-injector/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $dot := . }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,7 +73,10 @@ spec:
             value: {{ .Values.debug | quote }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
-            value: {{ $value }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "azure-key-vault-to-kubernetes.fullname" $dot }}-env
+                key: {{ $key }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/stable/azure-key-vault-env-injector/templates/secrets.yaml
+++ b/stable/azure-key-vault-env-injector/templates/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "azure-key-vault-to-kubernetes.fullname" . }}-env
+  labels:
+    app: {{ template "azure-key-vault-to-kubernetes.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
Both azure-key-vault-controller and azure-key-vault-env-injector currently store Azure credentials (specifically AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET) in env section of the deployment in plain text which is highly insecure.

Fixes #12 