### PR TITLE
Add PodDisruptionBudget to EnvInjector Helm chart

### DIFF
--- a/stable/azure-key-vault-env-injector/Chart.yaml
+++ b/stable/azure-key-vault-env-injector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.1.15
 description: A Helm chart that deploys the azure-key-vault-env-injector Helm chart
 name: azure-key-vault-env-injector
-version: 0.1.5
+version: 0.1.6
 maintainers:
 - name: Sparebanken Vest
   email: jon.torresdal@spv.no

--- a/stable/azure-key-vault-env-injector/templates/pdb.yaml
+++ b/stable/azure-key-vault-env-injector/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if gt .Values.replicaCount 1.0 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "azure-key-vault-to-kubernetes.fullname" . }}-pdb
+  labels:
+    app: {{ template "azure-key-vault-to-kubernetes.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}  
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: {{ template "azure-key-vault-to-kubernetes.name" . }}
+{{- end }}


### PR DESCRIPTION
This adds [PDBs](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) which should prevent cluster events from disrupting the service.

If replicaCount is greater than 1 it applies:
```
+ # Source: azure-key-vault-env-injector/templates/pdb.yaml
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: akvs-azure-key-vault-env-injector-pdb
   labels:
     app: azure-key-vault-env-injector
     chart: azure-key-vault-env-injector-0.1.5
     release: akvs
     heritage: Tiller
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: azure-key-vault-env-injector
```

Fixes #15 