### PR TITLE
Fix custom auth

### DIFF
--- a/stable/azure-key-vault-controller/templates/deployment.yaml
+++ b/stable/azure-key-vault-controller/templates/deployment.yaml
@@ -27,8 +27,6 @@ spec:
       - name: azure-keyvault-controller
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
-        args:
-          - "--cloudconfig={{ .Values.cloudConfig }}"
         env:
         - name: AZURE_VAULT_NORMAL_POLL_INTERVALS
           value: "{{ .Values.keyVault.polling.normalInterval }}"
@@ -48,16 +46,18 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
         {{- end }}
+        args:
+          - "--cloudconfig={{ .Values.cloudConfig }}"
         volumeMounts:
           - name: azure-config
             mountPath: "{{ .Values.cloudConfig }}"
             readOnly: true
-      {{- if .Values.image.pullSecret }}
-      imagePullSecrets:
-      - name: "{{ .Values.image.pullSecret }}"
-      {{- end }}
       volumes:
       - name: azure-config
         hostPath:
           path: "{{ .Values.cloudConfig }}"
           type: File
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: "{{ .Values.image.pullSecret }}"
+      {{- end }}

--- a/stable/azure-key-vault-controller/templates/deployment.yaml
+++ b/stable/azure-key-vault-controller/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
         {{- end }}
+    {{- if not .Values.keyVault.customAuth.enabled }}
         args:
           - "--cloudconfig={{ .Values.cloudConfig }}"
         volumeMounts:
@@ -57,6 +58,7 @@ spec:
         hostPath:
           path: "{{ .Values.cloudConfig }}"
           type: File
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
       - name: "{{ .Values.image.pullSecret }}"


### PR DESCRIPTION
I have Kubernetes cluster for developers in on-prem. I use Azure key vault for secrets.

**Problem:**
In on-prem cluster, azure-keyvault-controller pod couldn't start because it couldn't mount hostpath volume. 

I use customAuth and pass Azure credentials as environment variables as a result hostpath volume is unnecessary. My pr fix this issue. 