### PR TITLE
set failurePolicy to Fail

### DIFF
--- a/stable/azure-key-vault-env-injector/README.md
+++ b/stable/azure-key-vault-env-injector/README.md
@@ -108,3 +108,7 @@ The following tables lists configurable parameters of the azure-key-vault-env-in
 |service.name                             |webhook service name                         |azure-keyvault-secrets-webhook            |
 |service.type                             |webhook service type                         |ClusterIP                                 |
 |tolerations                              |tolerations to add                           |[]                                        |
+|webhook.logLevel                         |loglevel used for webhook                    |Info                                      |
+|webhook.dockerPulltimeout                |how long the image inspection can take max   |25                                        |
+|webhook.failurePolicy                    |`Ignore` Failures or `Fail` pod creation. In case of `Ignore` and a failure in the webhook, there will be no secret injected into the container runtime. | Ignore                        |
+

--- a/stable/azure-key-vault-env-injector/values.yaml
+++ b/stable/azure-key-vault-env-injector/values.yaml
@@ -40,7 +40,7 @@ metrics:
 
 webhook:
   logLevel: Info
-  dockerPullTimeout: 120 # will timeout after 120 seconds 
+  dockerPullTimeout: 20 # will timeout after 20 seconds
 
   # What will happen if the webhook fails? Ignore (continue) or Fail (prevent Pod from starting)?
   failurePolicy: Ignore
@@ -48,7 +48,7 @@ webhook:
   # https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   namespaceSelector:
     matchLabels:
-      azure-key-vault-env-injection: enabled # The webhook will only trigger i namespaces with this label
+      azure-key-vault-env-injection: enabled # The webhook will only trigger if namespace is labeled with this
 
     # Prevent env injection for pods in kube-system as recomended: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace
     matchExpressions:


### PR DESCRIPTION
# FailurePolicy 

This value should be set to `Fail` by default. As the webhook is responsible for exposing secrets to the actual runtime, the application will not be able to run until secrets are exposed to it. Therefore the webhook should fail the scheduling of a pod. 

An example to strengthen my argument:

1. Pod a requires the DB password for it's runtime. 
2. The webhook failed due to timeout in image inspection.
3. Pod is created without initContainer
4. In the app logs you will find: `"Password for user xxx is incorrect"`