### PR TITLE
Azure Key Vault Certificate Authentication from secret

### DIFF
--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -107,3 +107,11 @@ kubectl apply -f https://raw.githubusercontent.com/sparebankenvest/azure-key-vau
 |env_injector.webhook.podLabels                               |Labels to add to the webhook pod           |{} |
 |env_injector.webhook.securityContext.runAsUser               |Which user to run processes                  |65534|
 
+## Azure Key Vault Certificate authentication
+
+|               Parameter                           |                Description                   |                  Default                 |
+| ------------------------------------------------- | -------------------------------------------- | -----------------------------------------|
+|azureCertificate.enabled                           | if azure certificate authentication enabled  | false                                    |
+|azureCertificate.secret                            | name of the secret with akv certificate      | akv2k8s-certificate  |
+|azureCertificate.key                               | name of the key witin a secret with akv certificate (in p12 format), also used as certificate file name | akv2k8s-certificate.p12 |
+|azureCertificate.path                              | path where certificate is mounted | /etc/azure/ |

--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -48,6 +48,10 @@ spec:
           value: "{{ .Values.controller.logLevel }}"
         - name: LOG_FORMAT
           value: "{{ .Values.controller.logFormat }}"
+    {{- if .Values.azureCertificate.enabled }}
+        - name: AZURE_CERTIFICATE_PATH
+          value: "{{ print .Values.azureCertificate.path  .Values.azureCertificate.key }}"
+      {{- end }}
         {{- range $key, $value := .Values.global.env }}
         - name: {{ $key }}
           valueFrom:
@@ -66,15 +70,32 @@ spec:
         args:
           - "--cloudconfig={{ .Values.cloudConfig }}"
           # - "--version={{ .Values.controller.image.tag }}"
+      {{- end }}
         volumeMounts:
+    {{- if not .Values.controller.keyVault.customAuth.enabled }}
           - name: azure-config
             mountPath: "{{ .Values.cloudConfig }}"
             readOnly: true
+      {{- end }}
+    {{- if .Values.azureCertificate.enabled }}
+          - name: akv2k8s-certificate
+            mountPath: "{{ .Values.azureCertificate.path }}"
+            readOnly: true
+      {{- end }}
       volumes:
+    {{- if not .Values.controller.keyVault.customAuth.enabled }}
       - name: azure-config
         hostPath:
           path: "{{ .Values.cloudConfig }}"
           type: File
+      {{- end }}
+    {{- if .Values.azureCertificate.enabled }}
+      - name: akv2k8s-certificate
+        secret:
+          secretName: "{{ .Values.azureCertificate.secret }}"
+          items:
+          - key: "{{ .Values.azureCertificate.key }}"
+            path: "{{ .Values.azureCertificate.key }}"
       {{- end }}
       {{- if .Values.controller.image.pullSecret }}
       imagePullSecrets:

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -166,6 +166,10 @@ spec:
             value: {{ .Values.env_injector.webhook.logFormat | quote }}
           - name: METRICS_ENABLED
             value: {{ .Values.env_injector.metrics.enabled | quote }}
+      {{- if .Values.azureCertificate.enabled }}
+          - name: AZURE_CERTIFICATE_PATH
+            value: "{{ print .Values.azureCertificate.path  .Values.azureCertificate.key }}"
+        {{- end }}
           {{- range $key, $value := .Values.global.env }}
           - name: {{ $key }}
             valueFrom:
@@ -199,6 +203,11 @@ spec:
             name: azureconf
             readOnly: true
           {{- end }}
+    {{- if .Values.azureCertificate.enabled }}
+          - name: akv2k8s-certificate
+            mountPath: "{{ .Values.azureCertificate.path }}"
+            readOnly: true
+      {{- end }}
           securityContext:
             {{- if .Values.env_injector.webhook.securityContext }}
 {{ toYaml .Values.env_injector.webhook.securityContext | indent 12 }}
@@ -215,6 +224,14 @@ spec:
         hostPath:
           path: "{{ .Values.cloudConfig }}"
           type: File
+      {{- end }}
+    {{- if .Values.azureCertificate.enabled }}
+      - name: akv2k8s-certificate
+        secret:
+          secretName: "{{ .Values.azureCertificate.secret }}"
+          items:
+          - key: "{{ .Values.azureCertificate.key }}"
+            path: "{{ .Values.azureCertificate.key }}"
       {{- end }}
     {{- if .Values.env_injector.nodeSelector }}
       nodeSelector:

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -12,6 +12,12 @@ global: # values to be applied globally
 runningInsideAzureAks: true
 addAzurePodIdentityException: false
 cloudConfig: /etc/kubernetes/azure.json
+# Azure Key Vault certificate authentication
+azureCertificate:
+  enabled: false
+  secret: akv2k8s-certificate
+  key: akv2k8s-certificate.p12
+  path: /etc/azure/
 
 controller:
   enabled: true


### PR DESCRIPTION
Currently akv2k8s only allows to pass AZURE_CERTIFICATE_PATH environment variable that should map to the local file in the container with P12 certificate to be used for authentication on Azure, but there is no way to specify/pass content of the certificate file for akv2k8s pods. 
This change allows to pass secret to helm chart  that will be mounted to akv2k8s pods and used for authentication to Azure.