### PR TITLE
Endret default zeebe message size til 128KB for å få ned minnebruken …

### DIFF
--- a/stable/zeebe-cluster/values.yaml
+++ b/stable/zeebe-cluster/values.yaml
@@ -52,6 +52,9 @@ JavaOpts: >-
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
   -XX:+ExitOnOutOfMemoryError
+zeebeCfg:
+  network:
+    maxMessageSize: 128KB     
 
 labels:
   app: zeebe    


### PR DESCRIPTION
Endret default zeebe message size til 128KB for å få ned minnebruken i zeebe poddene