### PR TITLE
akv2k8s: Upgrade cert-manager api version to v1

### DIFF
--- a/stable/akv2k8s/templates/env-injector-cert-manager.yaml
+++ b/stable/akv2k8s/templates/env-injector-cert-manager.yaml
@@ -2,7 +2,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "envinjector.selfSignedIssuer" . }}
@@ -15,7 +15,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "envinjector.rootCACertificate" . }}
@@ -24,8 +24,8 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "envinjector.rootCACertificate" . }}
-  duration: 43800h # 5y
-  usages:  
+  duration: 43800h0m0s # 5y
+  usages:
   - digital signature
   - key encipherment
   - server auth
@@ -38,7 +38,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "envinjector.rootCAIssuer" . }}
@@ -52,7 +52,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "envinjector.servingCertificate" . }}
@@ -61,7 +61,7 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "envinjector.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "envinjector.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
Upgrade cert-manager api version to v1

Generated via [cert-manager kubectl plugin](https://cert-manager.io/docs/usage/kubectl-plugin/) `kubectl cert-manager convert -f <cert.yaml>`
