### PR TITLE
Allow passing sensitive values via secret references

### DIFF
--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart that deploys akv2k8s Controller and Env-Injector to Kubernetes
 
-![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 1.2.3](https://img.shields.io/badge/AppVersion-1.2.3-informational?style=flat-square)
+![Version: 2.0.10](https://img.shields.io/badge/Version-2.0.10-informational?style=flat-square) ![AppVersion: 1.2.3](https://img.shields.io/badge/AppVersion-1.2.3-informational?style=flat-square) 
 
 This chart will install:
   * a Controller for syncing AKV secrets to Kubernetes secrets
@@ -50,6 +50,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 |-----|------|---------|-------------|
 | name | string | `"akv2k8s"` | Name of Helm installation |
 | global.env | object | `{}` | Env vars to be used with all enabled pods, eg. for akv credentials |
+| global.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials -- Expected format: -- -- envFromSecret: -- - name: secret-name-1 -- - name: secret-name-2 |
 | global.logLevel | string | `"info"` | Sets klog log level info=2, debug=4, trace=6 |
 | global.logFormat | string | `"text"` | Sets klog log format text or json |
 | global.keyVaultAuth | string | `"azureCloudConfig"` | azureCloudConfig (aks credentials) or environment (custom) |
@@ -80,6 +81,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | controller.metrics.serviceMonitor.interval | string | `nil` | Override global.metrics.serviceMonitor.interval |
 | controller.metrics.serviceMonitor.additionalLabels | object | `nil` | Override global.metrics.serviceMonitor.additionalLabels |
 | controller.env | object | `{}` | Controller envs |
+| controller.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials -- Expected format: -- -- envFromSecret: -- - name: secret-name-1 -- - name: secret-name-2 |
 | controller.labels | object | `{}` | Controller labels |
 | controller.podLabels | object | `{}` | Controller pod labels |
 | controller.resources | object | `{}` | Controller resources |
@@ -124,6 +126,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | env_injector.serviceAccount.create | bool | `true` | Create service account for env-injector |
 | env_injector.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
 | env_injector.env | object | `{}` | Additional env vars to send to env-injector pods |
+| env_injector.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials -- Expected format: -- -- envFromSecret: -- - name: secret-name-1 -- - name: secret-name-2 |
 | env_injector.labels | object | `{}` | Additional labels |
 | env_injector.podLabels | object | `{}` | Additional pods labels |
 | env_injector.podDisruptionBudget.enabled | bool | `true` | Enable pod disruption budget |

--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -31,6 +31,17 @@ spec:
       - name: {{ .Values.controller.name }}
         image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        {{- if or .Values.global.envFromSecret .Values.controller.envFromSecret }}
+        envFrom:
+          {{- range $secretRef := .Values.controller.envFromSecret}}
+          - secretRef:
+              name: {{ $secretRef.name }}
+          {{- end }}
+          {{- range $secretRef := .Values.global.envFromSecret}}
+          - secretRef:
+              name: {{ $secretRef.name }}
+          {{- end }}
+        {{- end }}
         env:
         - name: AUTH_TYPE
           value: {{ $keyVaultAuth }}

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -40,6 +40,17 @@ spec:
             - "--versionenvimage={{ .Values.env_injector.envImage.tag }}"
             - "--v={{ template "envinjector.logLevel" . }}"
             - "--logging-format={{ template "envinjector.logFormat" . }}"
+          {{- if or .Values.global.envFromSecret .Values.env_injector.envFromSecret }}
+          envFrom:
+            {{- range $secretRef := .Values.env_injector.envFromSecret}}
+            - secretRef:
+                name: {{ $secretRef.name }}
+            {{- end }}
+            {{- range $secretRef := .Values.global.envFromSecret}}
+            - secretRef:
+                name: {{ $secretRef.name }}
+            {{- end }}
+          {{- end }}
           env:
           - name: HTTP_PORT
             value: {{ .Values.env_injector.service.internalHttpPort | quote }}

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -4,6 +4,13 @@ name: akv2k8s
 global:
   # -- Env vars to be used with all enabled pods, eg. for akv credentials
   env: {}
+  # -- Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials
+  # -- Expected format:
+  # --
+  # -- envFromSecret:
+  # -- - name: secret-name-1
+  # -- - name: secret-name-2
+  envFromSecret: []
   # -- Sets klog log level info=2, debug=4, trace=6
   logLevel: info
   # -- Sets klog log format text or json
@@ -94,6 +101,14 @@ controller:
   #   AZURE_TENANT_ID: <tenantId>
   #   AZURE_CLIENT_ID: <clientId>
   #   AZURE_CLIENT_SECRET: <clientSecret>
+
+  # -- Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials
+  # -- Expected format:
+  # --
+  # -- envFromSecret:
+  # -- - name: secret-name-1
+  # -- - name: secret-name-2
+  envFromSecret: []
 
   # -- Controller labels
   labels: {}
@@ -234,6 +249,14 @@ env_injector:
   #   AZURE_TENANT_ID: <tenantId>
   #   AZURE_CLIENT_ID: <clientId>
   #   AZURE_CLIENT_SECRET: <clientSecret>
+
+  # -- Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials
+  # -- Expected format:
+  # --
+  # -- envFromSecret:
+  # -- - name: secret-name-1
+  # -- - name: secret-name-2
+  envFromSecret: []
 
   # -- Additional labels
   labels: {}


### PR DESCRIPTION
As described in #49, passing sensitive values directly through helm values is insecure. This PR allows passing environment variables via a secret reference. 

Question: Do you need me to also bump the chart version inside this PR? Also, are there any places in the documentation I can adjust to cover this scenario?