### PR TITLE
Allow older policy apiversion

### DIFF
--- a/stable/akv2k8s/templates/env-injector-pdb.yaml
+++ b/stable/akv2k8s/templates/env-injector-pdb.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.env_injector.enabled .Values.env_injector.podDisruptionBudget.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{- else }}
 apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "akv2k8s.envinjector.fullname" . }}


### PR DESCRIPTION
This PR adds a check for an older PodDisruptionBudget version so the chart can be deployed in older clusters.