### PR TITLE
Allow for setting custom annotations of ServiceAccounts

### DIFF
--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -81,6 +81,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | controller.keyVaultAuth | string | `nil` | Override global - azureCloudConfig (aks credentials), environment (custom) |
 | controller.serviceAccount.create | bool | `true` | Create service account for controller |
 | controller.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| controller.serviceAccount.annotations | object | `{}` | Additional service account annotations |
 | controller.podSecurityContext | string | `nil` | Security context set on a pod level |
 | controller.priorityClassName | string | `""` | Controller PriorityClass name |
 | controller.securityContext.allowPrivilegeEscalation | bool | `true` | Must be `true` if using aks identity - can be set to false if userDefinedMSI is enabled |
@@ -138,6 +139,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | env_injector.metrics.serviceMonitor.additionalLabels | object | `nil` | Override global.metrics.serviceMonitor.additionalLabels |
 | env_injector.serviceAccount.create | bool | `true` | Create service account for env-injector |
 | env_injector.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| env_injector.serviceAccount.annotations | object | `{}` | Additional service account annotations |
 | env_injector.env | object | `{}` | Additional env vars to send to env-injector pods |
 | env_injector.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials |
 | env_injector.labels | object | `{}` | Additional labels |

--- a/stable/akv2k8s/templates/controller-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/controller-serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "controller.serviceAccountName" . }}
   labels:
     {{- include "akv2k8s.labels" . | nindent 4 }}
+  {{- if .Values.controller.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.controller.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   name: {{ template "envinjector.serviceAccountName" . }}
   labels:
     {{- include "akv2k8s.labels" . | nindent 4 }}
+  {{- if .Values.env_injector.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.env_injector.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -89,6 +89,8 @@ controller:
     # -- The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+    # -- Controller service account annotations
+    annotations: {}
 
   # -- Security context set on a pod level
   podSecurityContext:
@@ -268,6 +270,8 @@ env_injector:
     # -- The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+    # -- env-injector service account annotations
+    annotations: {}
 
   # -- Additional env vars to send to env-injector pods
   env: {}


### PR DESCRIPTION
As of Monday 10/24/2022, [AAD Pod Identity is deprecated](https://github.com/Azure/aad-pod-identity). We'd like to use it's successor: [Azure AD Workload Identity](https://github.com/Azure/azure-workload-identity).

To correctly configure it we need an option to specify annotations on Kubernetes Serivce Accounts as described [here](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html).