### PR TITLE
feat: workload identity, fix: cloudConfig path for MSI

### DIFF
--- a/stable/akv2k8s/templates/configmap-azureconfig.yaml
+++ b/stable/akv2k8s/templates/configmap-azureconfig.yaml
@@ -13,7 +13,11 @@ data:
         "subscriptionId": "{{ .Values.global.userDefinedMSI.subscriptionId }}",
         "aadClientId": "msi",
         "aadClientSecret": "msi",
+        {{- if .Values.global.userDefinedMSI.useWorkloadIdentityExtension }}
+        "useWorkloadIdentityExtension": true,
+        {{- else }}
         "useManagedIdentityExtension": true,
+        {{- end }}
         "userAssignedIdentityID": "{{ .Values.global.userDefinedMSI.msi }}",
     }
 {{- end }}

--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -100,9 +100,15 @@ spec:
         {{- if or $useCloudConfig .Values.controller.extraVolumeMounts }}
         volumeMounts:
           {{- if $useCloudConfig }}
+          {{- if .Values.global.userDefinedMSI.enabled }}
+          - name: azure-config
+            mountPath: "{{ dir .Values.cloudConfig }}"
+            readOnly: true
+          {{- else }}
           - name: azure-config
             mountPath: "{{ .Values.cloudConfig }}"
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.controller.extraVolumeMounts }}
           {{- toYaml .Values.controller.extraVolumeMounts | nindent 10 }}

--- a/stable/akv2k8s/templates/controller-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/controller-serviceaccount.yaml
@@ -9,4 +9,7 @@ metadata:
   annotations:
   {{ toYaml .Values.controller.serviceAccount.annotations | nindent 4 }}
   {{- end }}
+  {{- with .Values.controller.serviceAccount.labels -}}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -120,9 +120,15 @@ spec:
             name: ca-cert
           {{- end }}
           {{- if and $useCloudConfig .Values.env_injector.authService }}
+          {{- if .Values.global.userDefinedMSI.enabled }}
+          - mountPath: "{{ dir .Values.cloudConfig }}"
+            name: azureconf
+            readOnly: true
+          {{- else }}
           - mountPath: "{{ .Values.cloudConfig }}"
             name: azureconf
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.env_injector.extraVolumeMounts }}
           {{- toYaml .Values.env_injector.extraVolumeMounts | nindent 10 }}

--- a/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
   {{ toYaml .Values.env_injector.serviceAccount.annotations | nindent 4 }}
   {{- end }}
+  {{- with .Values.env_injector.serviceAccount.labels -}}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -29,6 +29,8 @@ global:
     tenantId:
     # -- Azure cloud type (usually AzurePublicCloud)
     azureCloudType:
+    # -- Whether to use Workload Identity Extension instead of Managed Identity
+    useWorkloadIdentityExtension: false
 
   metrics:
     # -- (bool) Enable prometheus metrics
@@ -91,6 +93,8 @@ controller:
     name:
     # -- Controller service account annotations
     annotations: {}
+    # -- Controller service account labels
+    labels: {}
 
   # -- Security context set on a pod level
   podSecurityContext:
@@ -272,6 +276,8 @@ env_injector:
     name:
     # -- env-injector service account annotations
     annotations: {}
+    # -- env-injector service account labels
+    labels: {}
 
   # -- Additional env vars to send to env-injector pods
   env: {}


### PR DESCRIPTION
This PR is open in support of https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/pull/443

Changes:
- Add support for Workload Identity:
  - Add labels customization for service accounts;
  - Add `useWorkloadIdentityExtension` flag;
- Fix `cloudConfig` (previously, the config would end up in `/etc/kubernetes/azure.json/azure.json` whereas the app would try to search it in `/etc/kubernetes/azure.json`.