### PR TITLE
Mount configmap with subPath

### DIFF
--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -103,6 +103,9 @@ spec:
           - name: azure-config
             mountPath: "{{ .Values.cloudConfig }}"
             readOnly: true
+            {{- if .Values.global.userDefinedMSI.enabled }}
+            subPath: azure.json
+            {{- end }}
           {{- end }}
           {{- if .Values.controller.extraVolumeMounts }}
           {{- toYaml .Values.controller.extraVolumeMounts | nindent 10 }}

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -123,6 +123,9 @@ spec:
           - mountPath: "{{ .Values.cloudConfig }}"
             name: azureconf
             readOnly: true
+            {{- if .Values.global.userDefinedMSI.enabled }}
+            subPath: azure.json
+            {{- end }}
           {{- end }}
           {{- if .Values.env_injector.extraVolumeMounts }}
           {{- toYaml .Values.env_injector.extraVolumeMounts | nindent 10 }}


### PR DESCRIPTION
When mounting azure.json from configmap (used when user defined MSI is set), it should mount it with subPath option so it gets mounted correct in the container.