### PR TITLE
Remove unused 'ca.crt' key from 'Secret' resources

### DIFF
--- a/stable/akv2k8s/templates/env-injector-apiservice.yaml
+++ b/stable/akv2k8s/templates/env-injector-apiservice.yaml
@@ -32,7 +32,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ $tlsCrt }}
   tls.key: {{ $tlsKey }}
-  ca.crt:  {{ $caCrt }}
 ---
 apiVersion: v1
 kind: Secret
@@ -45,7 +44,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ $caCrt }}
   tls.key: {{ $caKey }}
-  ca.crt:  {{ $caCrt }}
 {{- end }}
 ---
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
Kubernetes doesn't support creation of a `ca.crt` file in `kind: Secret` resources with `type: kubernetes.io/tls` with kubectl, so there is no way to create this resource with `kubectl create secret tls`

Additionally, I was unable to find a reference to `ca.crt` anywhere in the controller, keyvault injector, or webhook code.

As per the links below, the webhook serving cert file and key, as well as the webhook CA cert file and key are all named tls.crt and tls.key, and I could not find any other mention where this file could have come from:
- Serving cert file and key: https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/blob/15d87b2e3ec59f6d59fbe61b9676f5297bd54c0c/cmd/azure-keyvault-secrets-webhook/main.go\#L249
- CA cert file and key: https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/blob/44777aed5708e75f79c2108fca6d50c22783de35/cmd/azure-keyvault-secrets-webhook/auth/auth.go\#L52

Signed-off-by: Thomas Spear <tspear@conquestcyber.com>