### PR TITLE
Add labels to env-injector service account

### DIFF
--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -141,6 +141,7 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | env_injector.serviceAccount.create | bool | `true` | Create service account for env-injector |
 | env_injector.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
 | env_injector.serviceAccount.annotations | object | `{}` | env-injector service account annotations |
+| env_injector.serviceAccount.labels | object | `{}` | env-injector service account labels |
 | env_injector.env | object | `{}` | Additional env vars to send to env-injector pods |
 | env_injector.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials |
 | env_injector.labels | object | `{}` | Additional labels |

--- a/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ template "envinjector.serviceAccountName" . }}
   labels:
     {{- include "akv2k8s.labels" . | nindent 4 }}
+    {{- with .Values.env_injector.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if .Values.env_injector.serviceAccount.annotations }}
   annotations:
   {{ toYaml .Values.env_injector.serviceAccount.annotations | nindent 4 }}

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -274,6 +274,8 @@ env_injector:
     name:
     # -- env-injector service account annotations
     annotations: {}
+    # -- env-injector service account labels
+    labels: {}
 
   # -- Additional env vars to send to env-injector pods
   env: {}


### PR DESCRIPTION
Add labels to env-injector service account, needed for Workload Identity support for env injector SparebankenVest/azure-key-vault-to-kubernetes#442