### PR TITLE
Adds probes to the controler and liveness probe to the env-injector

### DIFF
--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -89,6 +89,16 @@ spec:
         ports:
           - name: http
             containerPort: {{ .Values.controller.service.internalHttpPort }}
+        readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: {{ .Values.controller.service.internalHttpPort }}
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /healthz
+            port: {{ .Values.controller.service.internalHttpPort }}
         {{- if .Values.controller.securityContext }}
         securityContext:
           {{ toYaml .Values.controller.securityContext | nindent 10 }}

--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -90,10 +90,10 @@ spec:
           - name: http
             containerPort: {{ .Values.controller.service.internalHttpPort }}
         readinessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /healthz
-              port: {{ .Values.controller.service.internalHttpPort }}
+          httpGet:
+            scheme: HTTP
+            path: /healthz
+            port: {{ .Values.controller.service.internalHttpPort }}
         livenessProbe:
           httpGet:
             scheme: HTTP

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -115,6 +115,11 @@ spec:
               scheme: HTTPS
               path: /healthz
               port: {{ .Values.env_injector.service.internalTlsPort }}
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: {{ .Values.env_injector.service.internalTlsPort }}
           volumeMounts:
           - mountPath: /var/serving-cert
             name: serving-cert


### PR DESCRIPTION
Solves: https://github.com/SparebankenVest/public-helm-charts/issues/97 

This PR adds probes to the pods that run using the existing /healthz endpoint for both the env-injector and the controller. The env-injector already had a readiness probe so only the liveness probe was added, the controller didn't have either so I've added both. 

Let me know if I need to make additional changes to comply with your pull request standards!

Kind regards,

Lennart