### PR TITLE
use policy/v1 instead of policy/v1beta

### DIFF
--- a/stable/azure-key-vault-env-injector/templates/pdb.yaml
+++ b/stable/azure-key-vault-env-injector/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.webhook.podDisruptionBudget.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "azure-key-vault-to-kubernetes.fullname" . }}


### PR DESCRIPTION
The policy/v1beta API version is deprecated since K8s version 1.25. 