### PR TITLE
Remove blank lines from chart output

### DIFF
--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "akv2k8s.labels" . | nindent 4 }}
     {{- if .Values.controller.labels }}
-    {{ toYaml .Values.controller.labels | indent 4 }}
+    {{- toYaml .Values.controller.labels | indent 4 }}
     {{- end }}
 spec:
   selector:
@@ -21,13 +21,13 @@ spec:
     metadata:
       {{- if .Values.controller.podAnnotations }}
       annotations:
-      {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "akv2k8s.selectors" . | nindent 8 }}
         {{- include "akv2k8s.components.controller" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
-        {{ toYaml .Values.controller.podLabels | nindent 8 }}
+        {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.controller.priorityClassName }}
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- if .Values.controller.podSecurityContext }}
       securityContext:
-        {{ toYaml .Values.controller.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "controller.serviceAccountName" . }}
       containers:
@@ -91,11 +91,11 @@ spec:
             containerPort: {{ .Values.controller.service.internalHttpPort }}
         {{- if .Values.controller.securityContext }}
         securityContext:
-          {{ toYaml .Values.controller.securityContext | nindent 10 }}
+          {{- toYaml .Values.controller.securityContext | nindent 10 }}
         {{- end }}
         {{- if .Values.controller.resources }}
         resources:
-          {{ toYaml .Values.controller.resources | nindent 10 }}
+          {{- toYaml .Values.controller.resources | nindent 10 }}
         {{- end }}
         {{- if or $useCloudConfig .Values.controller.extraVolumeMounts }}
         volumeMounts:
@@ -127,7 +127,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.controller.extraVolumes }}
-      {{ toYaml .Values.controller.extraVolumes | nindent 6 }}
+      {{- toYaml .Values.controller.extraVolumes | nindent 6 }}
       {{- end }}
       {{- end }}
       {{- if .Values.controller.image.pullSecret }}
@@ -136,14 +136,14 @@ spec:
       {{- end }}
       {{- if .Values.controller.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.controller.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.controller.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.tolerations }}
       tolerations:
-        {{ toYaml .Values.controller.tolerations | nindent 8 }}
+        {{- toYaml .Values.controller.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.affinity }}
       affinity:
-        {{ toYaml .Values.controller.affinity | nindent 8 }}
+        {{- toYaml .Values.controller.affinity | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/controller-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/controller-serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
   {{- if .Values.controller.serviceAccount.annotations }}
   annotations:
-  {{ toYaml .Values.controller.serviceAccount.annotations | nindent 4 }}
+  {{- toYaml .Values.controller.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/controller-servicemonitor.yaml
+++ b/stable/akv2k8s/templates/controller-servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
     {{- include "akv2k8s.components.controller" . | nindent 4 }}
     {{- if $labels }}
-    {{ toYaml $labels | nindent 4 }}
+    {{- toYaml $labels | nindent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/stable/akv2k8s/templates/env-injector-apiservice.yaml
+++ b/stable/akv2k8s/templates/env-injector-apiservice.yaml
@@ -90,7 +90,7 @@ webhooks:
       {{ template "envinjector.namespaceSelector" . }}
     matchExpressions:
     {{- if .Values.env_injector.namespaceSelector.matchExpressions }}
-      {{ toYaml .Values.env_injector.namespaceSelector.matchExpressions | nindent 4 }}
+      {{- toYaml .Values.env_injector.namespaceSelector.matchExpressions | nindent 4 }}
     {{- end }}
     - key: name
       operator: NotIn

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "akv2k8s.labels" . | nindent 4 }}
     {{- if .Values.env_injector.labels }}
-    {{ toYaml .Values.env_injector.labels | nindent 4 }}
+    {{- toYaml .Values.env_injector.labels | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.env_injector.replicaCount }}
@@ -24,14 +24,14 @@ spec:
         {{- include "akv2k8s.selectors" . | nindent 8 }}
         {{- include "akv2k8s.components.webhook" . | nindent 8 }}
         {{- if .Values.env_injector.podLabels }}
-        {{ toYaml .Values.env_injector.podLabels | nindent 8 }}
+        {{- toYaml .Values.env_injector.podLabels | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env-injector-apiservice.yaml") . | sha256sum }}
     spec:
       {{- if .Values.env_injector.podSecurityContext }}
       securityContext:
-        {{ toYaml .Values.env_injector.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.env_injector.podSecurityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "envinjector.serviceAccountName" . }}
       containers:
@@ -129,11 +129,11 @@ spec:
           {{- end }}
           {{- if .Values.env_injector.securityContext }}
           securityContext:
-            {{ toYaml .Values.env_injector.securityContext | nindent 12 }}
+            {{- toYaml .Values.env_injector.securityContext | nindent 12 }}
           {{- end }}
           {{- if .Values.env_injector.resources }}
           resources:
-            {{ toYaml .Values.env_injector.resources | nindent 12 }}
+            {{- toYaml .Values.env_injector.resources | nindent 12 }}
           {{- end }}
       volumes:
       - name: serving-cert
@@ -163,7 +163,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.env_injector.extraVolumes }}
-      {{ toYaml .Values.env_injector.extraVolumes | nindent 6 }}
+      {{- toYaml .Values.env_injector.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.env_injector.image.pullSecret }}
       imagePullSecrets:
@@ -171,14 +171,14 @@ spec:
       {{- end }}
       {{- if .Values.env_injector.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.env_injector.nodeSelector | nindent 8 }}
+        {{- toYaml .Values.env_injector.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.env_injector.tolerations }}
       tolerations:
-        {{ toYaml .Values.env_injector.tolerations | nindent 8 }}
+        {{- toYaml .Values.env_injector.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.env_injector.affinity }}
       affinity:
-        {{ toYaml .Values.env_injector.affinity | nindent 8 }}
+        {{- toYaml .Values.env_injector.affinity | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
+++ b/stable/akv2k8s/templates/env-injector-serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
   {{- if .Values.env_injector.serviceAccount.annotations }}
   annotations:
-  {{ toYaml .Values.env_injector.serviceAccount.annotations | nindent 4 }}
+  {{- toYaml .Values.env_injector.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/stable/akv2k8s/templates/env-injector-servicemonitor.yaml
+++ b/stable/akv2k8s/templates/env-injector-servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "akv2k8s.labels" . | nindent 4 }}
     {{- include "akv2k8s.components.controller" . | nindent 4 }}
     {{- if $labels }}
-    {{ toYaml $labels | nindent 4 }}
+    {{- toYaml $labels | nindent 4 }}
     {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
No-op change. Simply removes blank lines from the generated manifests