### PR TITLE
[akv2k8s] Fix broken volumeMount when userDefinedMSI is enabled

### DIFF
--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -110,9 +110,15 @@ spec:
         {{- if or $useCloudConfig .Values.controller.extraVolumeMounts }}
         volumeMounts:
           {{- if $useCloudConfig }}
+          {{- if .Values.global.userDefinedMSI.enabled }}
+          - name: azure-config
+            mountPath: "{{ dir .Values.cloudConfig }}"
+            readOnly: true
+          {{- else }}
           - name: azure-config
             mountPath: "{{ .Values.cloudConfig }}"
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.controller.extraVolumeMounts }}
           {{- toYaml .Values.controller.extraVolumeMounts | nindent 10 }}
@@ -127,7 +133,7 @@ spec:
           defaultMode: 420
           items:
           - key: azure.json
-            path: azure.json
+            path: "{{ base .Values.cloudConfig }}"
           name: {{ template "akv2k8s.name" . }}-azureconfig
       {{- else }}
       - name: azure-config

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -128,9 +128,15 @@ spec:
             name: ca-cert
           {{- end }}
           {{- if and $useCloudConfig .Values.env_injector.authService }}
+          {{- if .Values.global.userDefinedMSI.enabled }}
+          - mountPath: "{{ dir .Values.cloudConfig }}"
+            name: azureconf
+            readOnly: true
+          {{- else }}
           - mountPath: "{{ .Values.cloudConfig }}"
             name: azureconf
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.env_injector.extraVolumeMounts }}
           {{- toYaml .Values.env_injector.extraVolumeMounts | nindent 10 }}
@@ -161,7 +167,7 @@ spec:
           defaultMode: 420
           items:
           - key: azure.json
-            path: azure.json
+            path: "{{ base .Values.cloudConfig }}"
           name: {{ template "akv2k8s.name" . }}-azureconfig
       {{- else }}
       - name: azureconf


### PR DESCRIPTION
# Problem Statement
I encountered the following error when setting `global.userDefinedMSI.enabled` to true, causing the controller and env-injector pods to crash:

> \# E0609 21:45:27.641654       1 main.go:178] "failed to create cloud config provider for azure key vault" err="Failed reading azure config from /etc/kubernetes/azure.json, error: failed reading cloud config, error: read **/etc/kubernetes/azure.json: is a directory**" file="/etc/kubernetes/azure.json"
`

A short excerpt from the rendered `controller-deployment.yaml` explains the issue:
```yaml
        volumeMounts:
          - name: azure-config
            mountPath: "/etc/kubernetes/azure.json"
            readOnly: true
      volumes:
      - name: azure-config
        configMap:
          defaultMode: 420
          items:
          - key: azure.json
            path: azure.json
          name: akv2k8s-azureconfig
```
The volumeMount defines the mountPath (which becomes a directory inside the pod) as `/etc/kubernetes/azure.json` and mounts the ConfigMap as `azure.json` within it, causing it's real location to be `/etc/kubernetes/azure.json/azure.json`.

Hence, the error about `/etc/kubernetes/azure.json` being a directory is true.

When userDefinedMSI is enabled, the correct mountPath should be `/etc/kubernetes/`, so that the ConfigMap is mounted to `/etc/kubernetes/azure.json` as intended.

# Steps to Reproduce
Chart.yaml:
```yaml
---
apiVersion: v2
name: akv2k8s
version: 1.0.0
appVersion: 2.3.5
description: Installs akv2k8s
type: application
dependencies:
  - name: akv2k8s
    repository: https://charts.spvapi.no
    version: 2.3.5
```

values.yaml:
```
akv2k8s:
  global:
    metrics:
      enabled: true
    userDefinedMSI:
      enabled: true
      msi: 'msi-uuid'
      subscriptionId: 'subscription-uuid'
      tenantId: 'tenant-uuid'
      azureCloudType: 'AzureCloud'
```
Commands:
```
helm dependency build 
helm upgrade --install akv2k8s --create-namespace --namespace akv2k8s . --values values.yaml --debug
```

# Resolution
This PR resolves the issue by:
* Introducing an if-else-block in the volumeMount section of the deployments
  * If the ConfigMap is mounted (userDefinedMSI.enabled == true), use Helm's [dir](https://helm.sh/docs/chart_template_guide/function_list/#dir) function in order to get the directory path of  `.Values.cloudConfig` (e.g., `/etc/kubernetes/`)
* Using Helm's [base](https://helm.sh/docs/chart_template_guide/function_list/#base) function to set the path of the configMap's azure.json key to the filename set in `.Values.cloudConfig` (e.g., `azure.json`)

These changes fix the mentioned issue while still mounting the ConfigMap to whatever path is defined in `.Values.cloudConfig`.

.