### PR TITLE
Allow deploying RBAC resources when controller and env_injector are disabled to support separation of privileges

### DIFF
--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -64,8 +64,8 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | global.metrics.serviceMonitor.enabled | bool | `false` | Enable service-monitor |
 | global.metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval for service-monitor |
 | global.metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels for service-monitor |
-| rbac.create | bool | `true` | Specifies whether RBAC resources should be created |
-| rbac.podSecurityPolicies | object | `{}` |  |
+| global.rbac.create | bool | `true` | Specifies whether RBAC resources should be created |
+| global.rbac.podSecurityPolicies | object | `{}` |  |
 | addAzurePodIdentityException | bool | `false` | See https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.app-exception.md |
 | cloudConfig | string | `"/etc/kubernetes/azure.json"` | Path to cloud config on node (host path) or mounted configmap in pod |
 | watchAllNamespaces | bool | `true` | Watch all namespaces, set to false to run in release namespace only |
@@ -82,6 +82,8 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | controller.serviceAccount.create | bool | `true` | Create service account for controller |
 | controller.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
 | controller.serviceAccount.annotations | object | `{}` | Controller service account annotations |
+| controller.rbac | object | `{"create":null}` | Override global.rbac to create the controller rbac only |
+| controller.rbac.create | bool | `nil` | Override global.rbac.create |
 | controller.podSecurityContext | string | `nil` | Security context set on a pod level |
 | controller.priorityClassName | string | `""` | Controller PriorityClass name |
 | controller.securityContext.allowPrivilegeEscalation | bool | `true` | Must be `true` if using aks identity - can be set to false if userDefinedMSI is enabled |
@@ -140,6 +142,8 @@ kubectl apply -f https://raw.githubusercontent.com/SparebankenVest/azure-key-vau
 | env_injector.serviceAccount.create | bool | `true` | Create service account for env-injector |
 | env_injector.serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
 | env_injector.serviceAccount.annotations | object | `{}` | env-injector service account annotations |
+| env_injector.rbac | object | `{"create":null}` | Override global.rbac to create the env_injector rbac only |
+| env_injector.rbac.create | bool | `nil` | Override global.rbac.create |
 | env_injector.env | object | `{}` | Additional env vars to send to env-injector pods |
 | env_injector.envFromSecret | list | `[]` | Reference to secret containing variables to be used with all enabled pods, eg. for akv credentials |
 | env_injector.labels | object | `{}` | Additional labels |

--- a/stable/akv2k8s/templates/controller-rbac.yaml
+++ b/stable/akv2k8s/templates/controller-rbac.yaml
@@ -4,7 +4,7 @@
 {{- $roleType = "Role" -}}
 {{- $roleBindingType = "RoleBinding" -}}
 {{- end -}}
-{{- if and .Values.controller.enabled .Values.rbac.create -}}
+{{- if or .Values.global.rbac.create .Values.controller.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $roleType }}
 metadata:

--- a/stable/akv2k8s/templates/env-injector-rbac.yaml
+++ b/stable/akv2k8s/templates/env-injector-rbac.yaml
@@ -4,7 +4,7 @@
 {{- $roleType = "Role" -}}
 {{- $roleBindingType = "RoleBinding" -}}
 {{- end -}}
-{{- if and .Values.env_injector.enabled .Values.rbac.create -}}
+{{- if or .Values.global.rbac.create .Values.env_injector.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $roleType }}
 metadata:

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -41,10 +41,10 @@ global:
       # -- Additional labels for service-monitor
       additionalLabels: {}
 
-rbac:
-  # -- Specifies whether RBAC resources should be created
-  create: true
-  podSecurityPolicies: {}
+  rbac:
+    # -- Specifies whether RBAC resources should be created
+    create: true
+    podSecurityPolicies: {}
 
 # -- See https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.app-exception.md
 addAzurePodIdentityException: false
@@ -91,6 +91,11 @@ controller:
     name:
     # -- Controller service account annotations
     annotations: {}
+
+  # -- Override global.rbac to create the controller rbac only
+  rbac:
+    # -- (bool) Override global.rbac.create
+    create: # true/false
 
   # -- Security context set on a pod level
   podSecurityContext:
@@ -272,6 +277,11 @@ env_injector:
     name:
     # -- env-injector service account annotations
     annotations: {}
+
+  # -- Override global.rbac to create the env_injector rbac only
+  rbac:
+    # -- (bool) Override global.rbac.create
+    create: # true/false
 
   # -- Additional env vars to send to env-injector pods
   env: {}


### PR DESCRIPTION
This will make it possible to leverage the helm chart to deploy RBAC separately from the services.

As an infrastructure security engineer, I need to be able to deploy the RBAC resources from this chart in a project that we use to centralize management of cluster resources that require higher privileges to deploy them, like Roles, RoleBindings, ClusterRoles, ClusterRoleBindings, etc.

We manage service accounts centrally, and use our own chart for that purpose, but for these resources, we prefer to leverage the public chart with our own values, so as to simplify updates in the future.

When this is merged, I'll be able to do `helm install akv2k8s . --set env_injector.enabled=false --set controller.enabled=false --set global.rbac.create=false --set env_injector.rbac.create=true` to install only the rbac resources for the env-injector, or replace `--set env_injector.rbac.create=true` with `--set controller.rbac.create=true` to install only the rbac resources for the controller, or just simply do `helm install akv2k8s . --set env_injector.enabled=false --set controller.enabled=false` to install only the rbac resources for both the controller and env-injector.