### PR TITLE
Allow setting automountServiceAccountToken

### DIFF
--- a/stable/akv2k8s/Chart.yaml
+++ b/stable/akv2k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: A Helm chart that deploys akv2k8s Controller and Env-Injector to Kubernetes
 name: akv2k8s
-version: 2.6.0
+version: 2.6.1
 
 maintainers:
 - name: Jon Arild Tørresdal

--- a/stable/akv2k8s/templates/controller-deployment.yaml
+++ b/stable/akv2k8s/templates/controller-deployment.yaml
@@ -42,6 +42,7 @@ spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName | indent 4}}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
       {{- if .Values.controller.podSecurityContext }}
       securityContext:
         {{ toYaml .Values.controller.podSecurityContext | nindent 8 }}

--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{ toYaml .Values.env_injector.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.env_injector.automountServiceAccountToken }}
       {{- if .Values.env_injector.podSecurityContext }}
       securityContext:
         {{ toYaml .Values.env_injector.podSecurityContext | nindent 8 }}

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -99,6 +99,9 @@ controller:
     # -- (bool) Override global.rbac.create
     create: # true/false
 
+  # -- If set to `false`, must manually mount Kubernetes API credentials
+  automountServiceAccountToken: true
+
   # -- Security context set on a pod level
   podSecurityContext:
 
@@ -233,6 +236,10 @@ env_injector:
       ca:
         # -- Custom CA certificate, required when `env_injector.certificate.custom.enabled=true`
         crt:
+
+  # -- If set to `false`, must manually mount Kubernetes API credentials
+  automountServiceAccountToken: true
+
   # -- Security context set on a pod level
   podSecurityContext:
 


### PR DESCRIPTION
Azure Microsoft defender reported a High Severity security finding as below

"Kubernetes clusters should disable automounting API credentials" - Disable automounting API credentials to prevent a potentially compromised Pod resource to run API commands against Kubernetes clusters. For more information, see https://aka.ms/kubepolicydoc.

So in order to mitigate the above finding need to disable automounting of service account token by setting automountServiceAccountToken = false .
This is not possible with the chart currently, so opening this PR to support this (while keeping the default behavior as-is).
Tested and working.

Note to anyone looking to disable automountServiceAccountToken on akv2k8s - while it is best-practice to disable, the app still requires the Kubernetes credentials, so in order for this to work you must also manually mount the service account credentials, example:

```
controller:
    extraVolumes:
      - name: kube-api-access
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              expirationSeconds: 3607
              path: token
          - configMap:
              items:
              - key: ca.crt
                path: ca.crt
              name: kube-root-ca.crt
          - downwardAPI:
              items:
              - fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
                path: namespace
    extraVolumeMounts:
      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        name: kube-api-access
        readOnly: true


env_injector:
    extraVolumes:
      - name: kube-api-access
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              expirationSeconds: 3607
              path: token
          - configMap:
              items:
              - key: ca.crt
                path: ca.crt
              name: kube-root-ca.crt
          - downwardAPI:
              items:
              - fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
                path: namespace
    extraVolumeMounts:
      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        name: kube-api-access
        readOnly: true
```