### PR TITLE
Enable defining priorityClassName for the Env Injector

### DIFF
--- a/stable/akv2k8s/templates/env-injector-deployment.yaml
+++ b/stable/akv2k8s/templates/env-injector-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{ toYaml .Values.env_injector.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.env_injector.priorityClassName }}
+      priorityClassName: {{ .Values.env_injector.priorityClassName }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.env_injector.automountServiceAccountToken }}
       {{- if .Values.env_injector.podSecurityContext }}
       securityContext:

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -243,6 +243,9 @@ env_injector:
   # -- Security context set on a pod level
   podSecurityContext:
 
+  # -- Env-injector PriorityClass name
+  priorityClassName: ""
+
   securityContext:
     # -- Must be `true` if using aks identity - can be set to false if userDefinedMSI is enabled, or Azure AD Pod Identity is used
     allowPrivilegeEscalation: true


### PR DESCRIPTION
This PR enables assigning a priorityClassName to the env injector.

This is important because it is a runtime dependency of everything that uses env injection.