### PR TITLE
Don't set caBundle in the env-injector mutatingWebhookConfiguration when useCertManager is set to true

### DIFF
--- a/stable/akv2k8s/Chart.yaml
+++ b/stable/akv2k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.3
 description: A Helm chart that deploys akv2k8s Controller and Env-Injector to Kubernetes
 name: akv2k8s
-version: 2.7.2
+version: 2.7.3
 
 maintainers:
 - name: Jon Arild Tørresdal

--- a/stable/akv2k8s/templates/env-injector-apiservice.yaml
+++ b/stable/akv2k8s/templates/env-injector-apiservice.yaml
@@ -72,7 +72,9 @@ webhooks:
       name: {{ template "akv2k8s.envinjector.fullname" . }}
       path: /pods
       port: {{ .Values.env_injector.service.externalTlsPort }}
+{{- if not .Values.env_injector.certificate.useCertManager }}
     caBundle: {{ $caCrt }}
+{{- end }}
   rules:
   - operations:
     - CREATE


### PR DESCRIPTION
Setting the `webhooks[].clientConfig.caBundle` field to an empty string in the `mutatingWebhookConfiguration` and instructing the cert-manager to inject the caBundle leads ArgoCD to remove the injected bundle and set the field back to an empty string.