### PR TITLE
Update CODEOWNERS team to team-plattform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-* @SparebankenVest/sre
+* @SparebankenVest/team-plattform


### PR DESCRIPTION
This PR updates the CODEOWNERS file to replace the 'sre' team with 'team-plattform'.