### PR TITLE
Bump akv2k8s helm chart to 2.8.2 (appVersion 1.8.2)

### DIFF
--- a/stable/akv2k8s/Chart.yaml
+++ b/stable/akv2k8s/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.8.1
+appVersion: 1.8.2
 description: A Helm chart that deploys akv2k8s Controller and Env-Injector to Kubernetes
 name: akv2k8s
-version: 2.8.1
+version: 2.8.2
 
 maintainers:
 - name: Jon Arild Tørresdal

--- a/stable/akv2k8s/README.md
+++ b/stable/akv2k8s/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart that deploys akv2k8s Controller and Env-Injector to Kubernetes
 
-![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square) ![AppVersion: 1.8.2](https://img.shields.io/badge/AppVersion-1.8.2-informational?style=flat-square)
 
 This chart will install:
   * a Controller for syncing AKV secrets to Kubernetes secrets
@@ -14,6 +14,7 @@ For more information and installation instructions see the official documentatio
 
 | Helm Chart                         | Controller | Env Injector | CA Bundle Controller | Env Injector Sidecar |
 | ---------------------------------- | ---------- | ------------ | -------------------- | -------------------- |
+| `2.8.2` | `1.8.2`    | `1.8.2`      | `removed`            | `1.8.2`              |
 | `2.8.1` | `1.8.1`    | `1.8.1`      | `removed`            | `1.8.1`              |
 | `2.8.0` | `1.8.0`    | `1.8.0`      | `removed`            | `1.8.0`              |
 | `2.7.3` | `1.7.4`    | `1.7.4`      | `removed`            | `1.7.4`              |

--- a/stable/akv2k8s/values.yaml
+++ b/stable/akv2k8s/values.yaml
@@ -70,7 +70,7 @@ controller:
     # -- Image repository that contains the controller image
     repository: spvest/azure-keyvault-controller
     # -- Image tag
-    tag: 1.8.1
+    tag: 1.8.2
     # -- Image pull policy for controller
     pullPolicy: IfNotPresent
 
@@ -196,7 +196,7 @@ env_injector:
     # -- Image repository that contains the env-injector image
     repository: spvest/azure-keyvault-webhook
     # -- Image tag
-    tag: 1.8.1
+    tag: 1.8.2
     # -- Image pull policy for env-injector
     pullPolicy: IfNotPresent
 
@@ -207,7 +207,7 @@ env_injector:
     # -- Image repository that contains the vaultenv image
     repository: spvest/azure-keyvault-env
     # -- Image tag
-    tag: 1.8.1
+    tag: 1.8.2
     # -- Image pull policy for vaultenv
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Changes

- Bump chart version from 2.8.1 to 2.8.2
- Bump appVersion from 1.8.1 to 1.8.2
- Update controller image tag to 1.8.2
- Update env-injector image tag to 1.8.2
- Update env-injector sidecar (vaultenv) image tag to 1.8.2
- Update README version table and badges